### PR TITLE
test: cleanup testing examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,28 +17,6 @@ http/testdata/http-tinygo/main.wasm: http/testdata/http-tinygo/main.go
 	tinygo build -target=wasi -gc=leaking -no-debug -o http/testdata/http-tinygo/main.wasm http/testdata/http-tinygo/main.go
 
 # ----------------------------------------------------------------------
-# Build examples
-# ----------------------------------------------------------------------
-EXAMPLES_DIR = examples
-
-.PHONY: build-examples
-build-examples: generate
-build-examples: $(EXAMPLES_DIR)/http-tinygo-outbound-http/outbound-http-to-same-app/main.wasm
-build-examples: $(EXAMPLES_DIR)/http-tinygo-outbound-http/tinygo-hello/main.wasm
-build-examples: $(EXAMPLES_DIR)/http-tinygo/main.wasm
-build-examples: $(EXAMPLES_DIR)/tinygo-outbound-redis/main.wasm
-build-examples: $(EXAMPLES_DIR)/tinygo-redis/main.wasm
-build-examples: $(EXAMPLES_DIR)/tinygo-key-value/main.wasm
-build-examples: $(EXAMPLES_DIR)/tinygo-sqlite/main.wasm
-build-examples: $(EXAMPLES_DIR)/tinygo-llm/main.wasm
-build-examples: $(EXAMPLES_DIR)/tinygo-outbound-mysql/main.wasm
-build-examples: $(EXAMPLES_DIR)/tinygo-outbound-pg/main.wasm
-build-examples: $(EXAMPLES_DIR)/variables-tinygo/main.wasm
-
-$(EXAMPLES_DIR)/%/main.wasm: $(EXAMPLES_DIR)/%/main.go
-	tinygo build -target=wasi -gc=leaking -no-debug -o $@ $<
-
-# ----------------------------------------------------------------------
 # Generate C bindings
 # ----------------------------------------------------------------------
 GENERATED_SPIN_VARIABLES = variables/spin-config.c variables/spin-config.h
@@ -117,14 +95,4 @@ clean:
 	rm -f $(GENERATED_LLM)
 	rm -f $(GENERATED_OUTBOUND_MYSQL)
 	rm -f $(GENERATED_SDK_VERSION)
-	rm -f http/testdata/http-tinygo/main.wasm
-	rm -f $(EXAMPLES_DIR)/http-tinygo/main.wasm
-	rm -f $(EXAMPLES_DIR)/http-tinygo-outbound-http/main.wasm
-	rm -f $(EXAMPLES_DIR)/tinygo-outbound-redis/main.wasm
-	rm -f $(EXAMPLES_DIR)/tinygo-redis/main.wasm
-	rm -f $(EXAMPLES_DIR)/tinygo-key-value/main.wasm
-	rm -f $(EXAMPLES_DIR)/tinygo-sqlite/main.wasm
-	rm -f $(EXAMPLES_DIR)/tinygo-llm/main.wasm
-	rm -f $(EXAMPLES_DIR)/tinygo-outbound-mysql/main.wasm
-	rm -f $(EXAMPLES_DIR)/tinygo-outbound-pg/main.wasm
 	rm -f $(SDK_VERSION_DEST_FILES)

--- a/integration_test.go
+++ b/integration_test.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -141,15 +143,12 @@ func TestHTTPTriger(t *testing.T) {
 
 // TestBuildExamples ensures that the tinygo examples will build successfully.
 func TestBuildExamples(t *testing.T) {
-	for _, example := range []string{
-		"examples/http-tinygo",
-		"examples/http-tinygo-outbound-http",
-		"examples/tinygo-outbound-redis",
-		"examples/tinygo-redis",
-		"examples/tinygo-key-value",
-		"examples/variables-tinygo",
-	} {
-		build(t, example)
+	examples, err := os.ReadDir("examples")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, example := range examples {
+		build(t, filepath.Join("examples", example.Name()))
 	}
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -42,13 +42,16 @@ type testSpin struct {
 	cmd    *exec.Cmd
 }
 
-func startSpin(t *testing.T, spinfile string) *testSpin {
-	// long timeout because... ci
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+func startSpin(t *testing.T, dir string) *testSpin {
+	buildApp(t, dir)
 
 	url := getFreePort(t)
 
-	cmd := exec.CommandContext(ctx, spinBinary, "up", "--build", "--file", spinfile, "--listen", url)
+	// long timeout because... ci
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+
+	cmd := exec.CommandContext(ctx, spinBinary, "up", "--listen", url)
+	cmd.Dir = dir
 	stderr := new(bytes.Buffer)
 	cmd.Stderr = stderr
 	if err := cmd.Start(); err != nil {
@@ -72,10 +75,10 @@ func startSpin(t *testing.T, spinfile string) *testSpin {
 	}
 }
 
-func build(t *testing.T, dir string) {
+func buildApp(t *testing.T, dir string) {
 	t.Helper()
 
-	t.Log("building example: ", dir)
+	t.Log("building application: ", dir)
 
 	cmd := exec.Command(spinBinary, "build")
 	cmd.Dir = dir
@@ -89,7 +92,7 @@ func build(t *testing.T, dir string) {
 }
 
 func TestSpinRoundTrip(t *testing.T) {
-	spin := startSpin(t, "http/testdata/spin-roundtrip/spin.toml")
+	spin := startSpin(t, "http/testdata/spin-roundtrip")
 	defer spin.cancel()
 
 	resp := retryGet(t, spin.url+"/hello")
@@ -113,7 +116,7 @@ func TestSpinRoundTrip(t *testing.T) {
 }
 
 func TestHTTPTriger(t *testing.T) {
-	spin := startSpin(t, "http/testdata/http-tinygo/spin.toml")
+	spin := startSpin(t, "http/testdata/http-tinygo")
 	defer spin.cancel()
 
 	resp := retryGet(t, spin.url+"/hello")
@@ -148,7 +151,7 @@ func TestBuildExamples(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, example := range examples {
-		build(t, filepath.Join("examples", example.Name()))
+		buildApp(t, filepath.Join("examples", example.Name()))
 	}
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -78,7 +78,7 @@ func startSpin(t *testing.T, dir string) *testSpin {
 func buildApp(t *testing.T, dir string) {
 	t.Helper()
 
-	t.Log("building application: ", dir)
+	t.Log("building application:", dir)
 
 	cmd := exec.Command(spinBinary, "build")
 	cmd.Dir = dir
@@ -151,7 +151,11 @@ func TestBuildExamples(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, example := range examples {
-		buildApp(t, filepath.Join("examples", example.Name()))
+		example := example
+		t.Run(example.Name(), func(t *testing.T) {
+			t.Parallel()
+			buildApp(t, filepath.Join("examples", example.Name()))
+		})
 	}
 }
 


### PR DESCRIPTION
- Remove redundant building of examples in the Makefile
- Split building and starting the Spin apps to fail faster if there's a build issue