### PR TITLE
fix: update Makefile and integration tests probably side-effect from …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,17 +23,18 @@ EXAMPLES_DIR = examples
 
 .PHONY: build-examples
 build-examples: generate
-build-examples: $(EXAMPLES_DIR)/http-tinygo-outbound-http/outbound-http-to-same-app/main.wasm
-build-examples: $(EXAMPLES_DIR)/http-tinygo-outbound-http/tinygo-hello/main.wasm
-build-examples: $(EXAMPLES_DIR)/http-tinygo/main.wasm
-build-examples: $(EXAMPLES_DIR)/tinygo-outbound-redis/main.wasm
-build-examples: $(EXAMPLES_DIR)/tinygo-redis/main.wasm
-build-examples: $(EXAMPLES_DIR)/tinygo-key-value/main.wasm
-build-examples: $(EXAMPLES_DIR)/tinygo-sqlite/main.wasm
-build-examples: $(EXAMPLES_DIR)/tinygo-llm/main.wasm
-build-examples: $(EXAMPLES_DIR)/tinygo-outbound-mysql/main.wasm
-build-examples: $(EXAMPLES_DIR)/tinygo-outbound-pg/main.wasm
-build-examples: $(EXAMPLES_DIR)/variables-tinygo/main.wasm
+build-examples: $(EXAMPLES_DIR)/http/main.wasm
+build-examples: $(EXAMPLES_DIR)/http-outbound/hello/main.wasm
+build-examples: $(EXAMPLES_DIR)/http-outbound/http-to-same-app/main.wasm
+build-examples: $(EXAMPLES_DIR)/http-router/main.wasm
+build-examples: $(EXAMPLES_DIR)/key-value/main.wasm
+build-examples: $(EXAMPLES_DIR)/llm/main.wasm
+build-examples: $(EXAMPLES_DIR)/mysql-outbound/main.wasm
+build-examples: $(EXAMPLES_DIR)/pg-outbound/main.wasm
+build-examples: $(EXAMPLES_DIR)/redis/main.wasm
+build-examples: $(EXAMPLES_DIR)/redis-outbound/main.wasm
+build-examples: $(EXAMPLES_DIR)/sqlite/main.wasm
+build-examples: $(EXAMPLES_DIR)/variables/main.wasm
 
 $(EXAMPLES_DIR)/%/main.wasm: $(EXAMPLES_DIR)/%/main.go
 	tinygo build -target=wasi -gc=leaking -no-debug -o $@ $<

--- a/integration_test.go
+++ b/integration_test.go
@@ -142,12 +142,17 @@ func TestHTTPTriger(t *testing.T) {
 // TestBuildExamples ensures that the tinygo examples will build successfully.
 func TestBuildExamples(t *testing.T) {
 	for _, example := range []string{
-		"examples/http-tinygo",
-		"examples/http-tinygo-outbound-http",
-		"examples/tinygo-outbound-redis",
-		"examples/tinygo-redis",
-		"examples/tinygo-key-value",
-		"examples/variables-tinygo",
+		"examples/http",
+		"examples/http-outbound",
+		"examples/http-router",
+		"examples/key-value",
+		"examples/llm",
+		"examples/mysql-outbound",
+		"examples/pg-outbound",
+		"examples/redis",
+		"examples/redis-outbound",
+		"examples/sqlite",
+		"examples/variables",
 	} {
 		build(t, example)
 	}


### PR DESCRIPTION
This PR updates the `Makefile` and integration tests with the new path names so that they now run correctly/pass. 

This was probably a side-effect from when this was split into separate repo. In any case, `make test` now passes on my machine.

Perhaps a good followup to this PR would be another PR to add a CI action for this repo? Let me know if that would be useful.