### PR TITLE
docs(*): Remove componentize-go as a prerequisite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,6 @@ Whenever WIT files are changed, added to, or removed from the `wit` directory, t
 ### Prerequisites
 
 - BASH or compatible shell
-- [**componentize-go**](https://github.com/bytecodealliance/componentize-go) - Latest version
 
 ### Run
 ```sh

--- a/examples/http-p3-raw/README.md
+++ b/examples/http-p3-raw/README.md
@@ -9,7 +9,6 @@ writing).
 
 #### Prerequisites
 
-- [componentize-go](https://github.com/bytecodealliance/componentize-go/)
 - Curl
 
 ```shell
@@ -46,4 +45,3 @@ curl -i \
     -H 'url: https://bytecodealliance.org/' \
     http://127.0.0.1:3000/hash-all
 ```
-

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -1,7 +1,6 @@
 # Requirements
 - [**go**](https://go.dev/dl/) - v1.25+
 - [**spin**](https://github.com/spinframework/spin) - Latest version
-- [**componentize-go**](https://github.com/bytecodealliance/componentize-go) - Latest version
 
 # Usage
 Build and run the Spin app:

--- a/examples/key-value/README.md
+++ b/examples/key-value/README.md
@@ -1,7 +1,6 @@
 # Requirements
 - [**go**](https://go.dev/dl/) - v1.25+
 - [**spin**](https://github.com/spinframework/spin) - Latest version
-- [**componentize-go**](https://github.com/bytecodealliance/componentize-go) - Latest version
 
 # Usage
 Build and run the Spin app:

--- a/examples/mqtt-outbound/README.md
+++ b/examples/mqtt-outbound/README.md
@@ -2,7 +2,6 @@
 - [**go**](https://go.dev/dl/) - v1.25+
 - [**spin**](https://github.com/spinframework/spin) - Latest version
 - [**docker**](https://docs.docker.com/get-started/get-docker/) - Latest version
-- [**componentize-go**](https://github.com/bytecodealliance/componentize-go) - Latest version
 
 # Usage
 In one terminal window, run:

--- a/examples/mysql-outbound/README.md
+++ b/examples/mysql-outbound/README.md
@@ -2,7 +2,6 @@
 - [**go**](https://go.dev/dl/) - v1.25+
 - [**spin**](https://github.com/spinframework/spin) - Latest version
 - [**docker**](https://docs.docker.com/get-started/get-docker/) - Latest version
-- [**componentize-go**](https://github.com/bytecodealliance/componentize-go) - Latest version
 
 # Usage
 In a terminal window, use the below command to run MySQL:

--- a/examples/redis-outbound/README.md
+++ b/examples/redis-outbound/README.md
@@ -2,7 +2,6 @@
 - [**go**](https://go.dev/dl/) - v1.25+
 - [**spin**](https://github.com/spinframework/spin) - Latest version
 - [**docker**](https://docs.docker.com/get-started/get-docker/) - Latest version
-- [**componentize-go**](https://github.com/bytecodealliance/componentize-go) - Latest version
 
 # Usage
 In one terminal window, you'll run a Redis container:

--- a/examples/variables/README.md
+++ b/examples/variables/README.md
@@ -1,7 +1,6 @@
 # Requirements
 - [**go**](https://go.dev/dl/) - v1.25+
 - [**spin**](https://github.com/spinframework/spin) - Latest version
-- [**componentize-go**](https://github.com/bytecodealliance/componentize-go) - Latest version
 
 # Usage
 Build and run the Spin app:


### PR DESCRIPTION
componentize-go is installed automatically with go tools